### PR TITLE
Add master TUI browser for app list

### DIFF
--- a/DIFF_20250811_043431.md
+++ b/DIFF_20250811_043431.md
@@ -1,0 +1,4 @@
+## Changes on 2025-08-11 04:34:31 UTC
+
+- Added `master_tui.py` providing a curses-based browser for the applications listed in `data/apps.csv`.
+- Created this `DIFF_20250811_043431.md` file to document repository changes.

--- a/RECOMMENDATIONS_20250811_043435.md
+++ b/RECOMMENDATIONS_20250811_043435.md
@@ -1,0 +1,4 @@
+## Recommendations as of 2025-08-11 04:34:35 UTC
+
+- Consider adding search functionality to `master_tui.py` to quickly filter applications by name or category.
+- Adding basic tests for the TUI script would help ensure compatibility with different terminal environments.

--- a/master_tui.py
+++ b/master_tui.py
@@ -1,0 +1,65 @@
+import csv
+import curses
+import textwrap
+import webbrowser
+from pathlib import Path
+
+DATA_FILE = Path(__file__).parent / 'data' / 'apps.csv'
+
+
+def load_apps():
+    with DATA_FILE.open(newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def draw(stdscr, apps, current):
+    stdscr.clear()
+    height, width = stdscr.getmaxyx()
+
+    title = "Awesome CLI Apps Browser - j/k or arrows to move, Enter to open, q to quit"
+    stdscr.addstr(0, 0, title[: width - 1])
+
+    max_lines = height - 4
+    start = max(0, min(current - max_lines // 2, len(apps) - max_lines))
+    for idx, app in enumerate(apps[start : start + max_lines]):
+        line = f"{app['name']} ({app['category']})"
+        if start + idx == current:
+            stdscr.addstr(idx + 1, 0, line[: width - 1], curses.A_REVERSE)
+        else:
+            stdscr.addstr(idx + 1, 0, line[: width - 1])
+
+    desc = apps[current]['description']
+    desc_lines = textwrap.wrap(desc, width - 1)
+    for i, line in enumerate(desc_lines):
+        stdscr.addstr(height - len(desc_lines) + i - 1, 0, line)
+
+    stdscr.refresh()
+
+
+def open_link(app):
+    url = app.get('homepage') or app.get('git')
+    if url:
+        webbrowser.open(url)
+
+
+def main(stdscr):
+    curses.curs_set(0)
+    apps = load_apps()
+    current = 0
+    draw(stdscr, apps, current)
+    while True:
+        key = stdscr.getch()
+        if key in (ord('q'), 27):
+            break
+        elif key in (curses.KEY_DOWN, ord('j')) and current < len(apps) - 1:
+            current += 1
+        elif key in (curses.KEY_UP, ord('k')) and current > 0:
+            current -= 1
+        elif key in (curses.KEY_ENTER, ord('\n'), ord('\r')):
+            open_link(apps[current])
+        draw(stdscr, apps, current)
+
+
+if __name__ == '__main__':
+    curses.wrapper(main)


### PR DESCRIPTION
## Summary
- implement `master_tui.py` to browse applications in `data/apps.csv`
- record changes in `DIFF_20250811_043431.md`
- add recommendations file `RECOMMENDATIONS_20250811_043435.md`

## Testing
- `python -m py_compile master_tui.py`


------
https://chatgpt.com/codex/tasks/task_e_689972697450832ab95d3010a949504d

## Summary by Sourcery

Add a new curses-based terminal UI to browse and open applications from data/apps.csv and include change logs and improvement suggestions

New Features:
- Introduce master_tui.py for navigating, viewing, and opening app entries via keyboard controls

Documentation:
- Add DIFF_20250811_043431.md to document repository changes
- Add RECOMMENDATIONS_20250811_043435.md with future enhancement suggestions